### PR TITLE
Clear the community repo if present in GH testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
           set -x
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
-          sudo microk8s addons repo remove community
+          sudo microk8s addons repo remove community || true
           sudo microk8s addons repo add community .
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,6 @@ jobs:
           set -x
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
-          sudo microk8s addons repo remove community || true
           sudo microk8s addons repo add community .
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,10 @@ jobs:
           set -x
           sudo snap install microk8s --classic --channel=latest/edge
           sudo microk8s status --wait-ready --timeout 600
+          if sudo microk8s addons repo list | grep community
+          then
+            sudo microk8s addons repo remove community
+          fi
           sudo microk8s addons repo add community .
           export UNDER_TIME_PRESSURE="True"
           export SKIP_PROMETHEUS="False"


### PR DESCRIPTION
If the community addons are not disabled by default we make sure we remove the repo before we dd the one we test.